### PR TITLE
Add prune subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ go install github.com/umlx5h/gtrash@latest
 ### Build from source
 
 ```bash
-git clone https://github.com/umlx5h/gtrash.git
+git clone https://github.com/umlx5h/gtrash.git --depth 1
 cd gtrash
 go build
 ./gtrash
@@ -360,13 +360,14 @@ Not recommended due to potential risks, unintentionally executing actual `rm` co
 
 As `gtrash` isn't fully compatible with `rm`, it's prudent to establish different aliases to avoid confusion and prevent accidental deletion of files.
 
-Consider setting up alternative aliases, such as:
+Consider setting up alternative short aliases, such as:
 
 ```bash
 alias gp='gtrash put' # gtrash put
 alias gm='gtrash put' # gtrash move (easy to change to rm)
 alias tp='gtrash put' # trash put
 alias tm='gtrash put' # trash move (easy to change to rm)
+alias tt='gtrash put' # to trash
 ```
 
 If you are in the habit of using rm, consider creating an alias that displays a cautionary message.
@@ -630,13 +631,18 @@ Currently possible only by day.
 
 ```bash
 # Remove files deleted over a week ago
-$ gtrash find --day-old 7 --rm
+$ gtrash prune --day 7
 
-# Remove files deleted within the last 24 hours
-$ gtrash find --day-new 1 --rm
+# Almost the same as prune
+$ gtrash find --day-old 7 --rm
 ```
 
 Size-based:
+
+There are two methods.
+
+`find` filters by the specified size and removes them.
+
 ```bash
 # Remove trashed files larger than 10MB
 $ gtrash find --size-large 10mb --rm
@@ -651,8 +657,16 @@ $ gtrash find --size-large 1gb --rm
 $ gtrash find --size-small 0 --rm
 ```
 
-Sizes and dates can be combined, and other filters can be applied.
+`prune` removes large files first so that the overall trash size is smaller than the specified size:
+```
+# After this, the size of the trash can is guaranteed to be less than 5 GB.
+$ gtrash prune --size 5GB
 
+# If you want to exclude recently deleted files, you can also specify day.
+$ gtrash prune --size 5GB --day 7
+```
+
+Sizes and dates can be combined in `find`, and other filters can be applied:
 ```bash
 # Remove files older than a week and larger than 10MB
 $ gtrash find --day-old 7 --size-large 10mb --rm

--- a/internal/cmd/find.go
+++ b/internal/cmd/find.go
@@ -45,6 +45,8 @@ type findOptions struct {
 	showTrashPath bool
 
 	restoreTo string
+
+	trashDir string
 }
 
 func newFindCmd() *findCmd {
@@ -135,11 +137,22 @@ This is not necessary if running outside of a terminal`)
 	cmd.Flags().IntVar(&root.opts.dayOld, "day-old", 0, "Filter by deletion date (before X day)")
 	cmd.Flags().BoolVarP(&root.opts.showSize, "show-size", "S", false, `Show size always
 Automatically enabled if --sort size, --size-large, --size-small specified
-If the size could not be obtained, it will be displayed as '-'`)
+
+If the size could not be obtained, it will be displayed as '-'
+
+Note that this may take longer due to recursive size calcuration for directories.
+The folder size is cached, so it will run faster the next time.
+`)
 	cmd.Flags().BoolVar(&root.opts.showTrashPath, "show-trashpath", false, "Show trash path")
 	cmd.Flags().BoolVarP(&root.opts.reverse, "reverse", "r", false, "Reverse sort order (default: ascending)")
 	cmd.Flags().StringVar(&root.opts.restoreTo, "restore-to", "", "Restore to this path instead of original path")
 	cmd.Flags().IntVarP(&root.opts.last, "last", "n", 0, "Show n last files")
+	cmd.Flags().StringVar(&root.opts.trashDir, "trash-dir", "", `Specify a full path if you want to search only a specific trash can
+By default, all trash cans are searched.
+
+For $HOME trash only:
+    --trash-dir "$HOME/.local/share/Trash"
+`)
 
 	cmd.MarkFlagsMutuallyExclusive("rm", "restore")
 	cmd.MarkFlagsMutuallyExclusive("directory", "cwd")
@@ -175,6 +188,7 @@ func findCmdRun(args []string, opts findOptions) error {
 		trash.WithDay(opts.dayNew, opts.dayOld), // TODO: also set in restore?
 		trash.WithSize(opts.sizeLarge, opts.sizeSmall),
 		trash.WithLimitLast(opts.last),
+		trash.WithTrashDir(opts.trashDir),
 	)
 	if err := box.Open(); err != nil {
 		return err

--- a/internal/cmd/find.go
+++ b/internal/cmd/find.go
@@ -191,7 +191,13 @@ func findCmdRun(args []string, opts findOptions) error {
 		trash.WithTrashDir(opts.trashDir),
 	)
 	if err := box.Open(); err != nil {
-		return err
+		// no error only remove mode (consider executing via batch)
+		if opts.doRemove && errors.Is(err, trash.ErrNotFound) {
+			fmt.Printf("do nothing: %s\n", err)
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	listFiles(box.Files, box.GetSize, opts.showTrashPath)
@@ -212,9 +218,7 @@ func findCmdRun(args []string, opts findOptions) error {
 		if !opts.force && isTerminal && !tui.BoolPrompt("Are you sure you want to remove PERMENANTLY? ") {
 			return errors.New("do nothing")
 		}
-		if err := doRemove(box.Files); err != nil {
-			return err
-		}
+		doRemove(box.Files)
 
 	} else if opts.doRestore {
 		if opts.restoreTo != "" {

--- a/internal/cmd/metafix.go
+++ b/internal/cmd/metafix.go
@@ -57,11 +57,16 @@ func metafixCmdRun(opts metafixOptions) error {
 		trash.WithSortBy(trash.SortByName),
 	)
 	if err := box.Open(); err != nil {
-		return err
+		if errors.Is(err, trash.ErrNotFound) {
+			fmt.Printf("do nothing: %s\n", err)
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if len(box.OrphanMeta) == 0 {
-		fmt.Println("Not found invalid metadata")
+		fmt.Println("not found invalid metadata")
 		return nil
 	}
 

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+	"github.com/umlx5h/gtrash/internal/glog"
+	"github.com/umlx5h/gtrash/internal/trash"
+	"github.com/umlx5h/gtrash/internal/tui"
+)
+
+type pruneCmd struct {
+	cmd  *cobra.Command
+	opts pruneOptions
+}
+
+type pruneOptions struct {
+	force bool
+
+	day  int
+	size string // human size (e.g. 10MB, 1G)
+
+	maxTotalSize uint64 // byte, parse from size
+
+	trashDir string // $HOME/.local/share/Trash
+}
+
+func (o *pruneOptions) check() error {
+	if o.size != "" {
+		byte, err := humanize.ParseBytes(o.size)
+		if err != nil {
+			return fmt.Errorf("--size unit is invalid: %w", err)
+		}
+		o.maxTotalSize = byte
+	}
+	return nil
+}
+
+func newPruneCmd() *pruneCmd {
+	root := &pruneCmd{}
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Prune trash cans by day or size",
+		Long: `Description:
+  Pruning trash cans by day or size criteria.
+  Either the --day or --size option is required.
+
+  This command is also intended for use via cron.
+  By default, you may be prompted multiple times for each trash can.
+
+  If the file to be pruned does not exist, the program exits normally without doing anything.`,
+		Example: `  # Delete all files deleted a week ago
+  $ gtrash prune --day 7
+
+  # Delete all files deleted a week ago only within $HOME trash
+  $ gtrash prune --day 7 --trash-dir "$HOME/.local/share/Trash"
+
+  # Delete files in order from the largest to the smaller one so that the total size of the trash can is less than 5GB.
+  # This is useful when you want to keep as many files as possible, including old files, but want to reduce the size of the trash can below a certain level.
+  $ gtrash prune --size 5GB
+
+  # Delete large files first to keep the total remaining size under 5GB, while excluding files deleted in the last week.
+  # Note that adding the most recently deleted files may exceed 5GB.
+  $ gtrash prune --size 5GB --day 7`,
+		SilenceUsage:      true,
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := pruneCmdRun(root.opts); err != nil {
+				return err
+			}
+			if glog.ExitCode() > 0 {
+				return errContinue
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&root.opts.size, "size", "", `Remove files in order from the largest to the smaller one so that the overall size of the trash can is less than the specified size.
+If the total size of the trash can is smaller than the specified size, nothing is done.
+The total size is calculated by each trash can.
+
+If you want to delete files larger than the specified size, use the "find --size-large XX --rm" command.
+
+Can be specified in human format (e.g. 5MB, 1GB)
+
+If --day and --size are specified at the same time, the most recent X days are excluded from the calculation.
+This may be useful when you do not want to delete large files that have been recently deleted.
+`)
+	cmd.Flags().IntVar(&root.opts.day, "day", 0, "Remove all files deleted before X days")
+
+	cmd.Flags().BoolVarP(&root.opts.force, "force", "f", false, `Always execute without confirmation prompt
+This is not necessary if running outside of a terminal
+`)
+	cmd.Flags().StringVar(&root.opts.trashDir, "trash-dir", "", `Specify a full path if you want to prune only a specific trash can
+By default, all trash cans are pruned.
+
+For $HOME trash only:
+    --trash-dir "$HOME/.local/share/Trash"
+`)
+	cmd.Root().MarkFlagsOneRequired("size", "day")
+
+	root.cmd = cmd
+	return root
+}
+
+// Returns files to be deleted from files based on maxTotalSize
+// If maxTotalSize > total, nil is returned.
+//
+// Prerequisite: files are sorted in ascending order by size
+func getPruneFiles(files []trash.File, maxTotalSize uint64) (prune []trash.File, deleted uint64, total uint64) {
+	for i, f := range files {
+		// If the size cannot be obtained, it is treated as a minus value and should be at the top.
+		// This is always skipped and is not considered for deletion.
+		if f.Size == nil {
+			continue
+		}
+
+		size := uint64(*f.Size)
+		total += size
+
+		if prune == nil {
+			if total > maxTotalSize {
+				prune = files[i:]
+			}
+		}
+
+		if prune != nil {
+			deleted += size
+		}
+	}
+
+	if prune == nil {
+		return nil, 0, total
+	} else {
+		return prune, deleted, total
+	}
+}
+
+func pruneCmdRun(opts pruneOptions) error {
+	if err := opts.check(); err != nil {
+		return err
+	}
+
+	sortMethod := trash.SortByDeletedAt
+
+	sizeMode := opts.size != ""
+
+	if opts.size != "" {
+		sortMethod = trash.SortBySize
+	}
+
+	box := trash.NewBox(
+		trash.WithSortBy(sortMethod),
+		trash.WithGetSize(sizeMode),
+		trash.WithAscend(true),
+		trash.WithDay(0, opts.day),
+		trash.WithTrashDir(opts.trashDir),
+	)
+	if err := box.Open(); err != nil {
+		if errors.Is(err, trash.ErrNotFound) {
+			fmt.Printf("do nothing: %s\n", err)
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	for i, trashDir := range box.TrashDirs {
+		files := box.FilesByTrashDir[trashDir]
+		if len(files) == 0 {
+			continue
+		}
+
+		var deleted, total uint64
+
+		if sizeMode {
+			files, deleted, total = getPruneFiles(files, opts.maxTotalSize)
+			if len(files) == 0 {
+				fmt.Printf("do nothing: trash size %s is smaller than %s (%s) in %s\n", humanize.Bytes(total), humanize.Bytes(opts.maxTotalSize), opts.size, trashDir)
+				continue
+			}
+		}
+
+		listFiles(files, sizeMode, false)
+
+		fmt.Printf("\nSelected %d files in %s\n", len(files), trashDir)
+
+		if sizeMode {
+			fmt.Printf("Current: %s, Deleted: %s, After: %s, Specified: %s\n\n", humanize.Bytes(total), humanize.Bytes(deleted), humanize.Bytes(total-deleted), humanize.Bytes(opts.maxTotalSize))
+		}
+
+		if !opts.force && isTerminal && !tui.BoolPrompt("Are you sure you want to remove PERMENANTLY? ") {
+			return errors.New("do nothing")
+		}
+		doRemove(files)
+
+		if i != len(box.TrashDirs)-1 {
+			fmt.Println("")
+		}
+	}
+
+	return nil
+}

--- a/internal/cmd/prune_test.go
+++ b/internal/cmd/prune_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/umlx5h/gtrash/internal/trash"
+)
+
+func newInt(i int64) *int64 {
+	return &i
+}
+
+func TestGetPruneFiles(t *testing.T) {
+	t.Run("should return prune files", func(t *testing.T) {
+		got, deleted, total := getPruneFiles([]trash.File{
+			{
+				Name: "a",
+				Size: newInt(20),
+			},
+			{
+				Name: "b",
+				Size: newInt(30),
+			},
+			{
+				Name: "c",
+				Size: newInt(50),
+			},
+			{
+				Name: "d",
+				Size: newInt(100),
+			},
+			{
+				Name: "e",
+				Size: newInt(150),
+			},
+		}, 100)
+
+		want := []trash.File{
+			{
+				Name: "d",
+				Size: newInt(100),
+			},
+			{
+				Name: "e",
+				Size: newInt(150),
+			},
+		}
+
+		assert.Equal(t, want, got)
+		assert.EqualValues(t, 250, deleted)
+		assert.EqualValues(t, 350, total)
+	})
+
+	t.Run("should prune files from larger files", func(t *testing.T) {
+		got, deleted, total := getPruneFiles([]trash.File{
+			{
+				Name: "a",
+				Size: newInt(20),
+			},
+			{
+				Name: "b",
+				Size: newInt(30),
+			},
+			{
+				Name: "c",
+				Size: newInt(50),
+			},
+		}, 30)
+
+		want := []trash.File{
+			{
+				Name: "b",
+				Size: newInt(30),
+			},
+			{
+				Name: "c",
+				Size: newInt(50),
+			},
+		}
+
+		assert.Equal(t, want, got)
+		assert.EqualValues(t, 80, deleted)
+		assert.EqualValues(t, 100, total)
+	})
+
+	t.Run("should return nil", func(t *testing.T) {
+		got, deleted, total := getPruneFiles([]trash.File{
+			{
+				Name: "a",
+				Size: newInt(20),
+			},
+			{
+				Name: "b",
+				Size: newInt(30),
+			},
+			{
+				Name: "c",
+				Size: newInt(50),
+			},
+		}, 100)
+
+		assert.Nil(t, got)
+		assert.EqualValues(t, 0, deleted)
+		assert.EqualValues(t, 100, total)
+	})
+
+}

--- a/internal/cmd/rm.go
+++ b/internal/cmd/rm.go
@@ -81,14 +81,12 @@ func removeCmdRun(args []string, opts removeOptions) error {
 		return errors.New("do nothing")
 	}
 
-	if err := doRemove(box.Files); err != nil {
-		return err
-	}
+	doRemove(box.Files)
 
 	return nil
 }
 
-func doRemove(files []trash.File) error {
+func doRemove(files []trash.File) {
 	var failed []trash.File
 
 	for _, file := range files {
@@ -111,6 +109,4 @@ func doRemove(files []trash.File) error {
 		fmt.Printf("Following %d files could not be deleted.\n", len(failed))
 		listFiles(failed, false, true)
 	}
-
-	return nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -130,6 +130,7 @@ func newRootCmd(version Version) *rootCmd {
 		newRemoveCmd().cmd,
 		newSummaryCmd().cmd,
 		newMetafixCmd().cmd,
+		newPruneCmd().cmd,
 	)
 	root.cmd = cmd
 	return root

--- a/internal/cmd/summary.go
+++ b/internal/cmd/summary.go
@@ -83,7 +83,7 @@ func summaryCmdRun(_ summaryOptions) error {
 		totalItem += item
 	}
 
-	if len(box.FilesByTrashDir) > 1 {
+	if len(box.TrashDirs) > 1 {
 		fmt.Printf("\n[total]\n")
 		fmt.Printf("item: %d\n", totalItem)
 		fmt.Printf("size: %s\n", humanize.Bytes(uint64(totalSize)))

--- a/internal/xdg/trashdir.go
+++ b/internal/xdg/trashdir.go
@@ -22,6 +22,7 @@ const (
 	trashDirTypeHome        trashDirType = "HOME"         // $XDG_DATA_HOME/Trash
 	trashDirTypeExternal    trashDirType = "EXTERNAL"     // $root/.Trash/$uid
 	trashDirTypeExternalAlt trashDirType = "EXTERNAL_ALT" // $root/.Trash-$uid
+	trashDirTypeManual      trashDirType = "MANUAL"       // any directory, specify by --trash-dir
 )
 
 type TrashDir struct {
@@ -60,6 +61,14 @@ func (d TrashDir) CreateDir() error {
 	}
 
 	return nil
+}
+
+func NewTrashDirManual(dir string) TrashDir {
+	return TrashDir{
+		Root:    filepath.Dir(dir),
+		Dir:     dir,
+		dirType: trashDirTypeManual,
+	}
 }
 
 // Scan and returns trash directories from all mountpoints

--- a/itest/trash_test.go
+++ b/itest/trash_test.go
@@ -86,7 +86,7 @@ func TestTrashAllType(t *testing.T) {
 			cmd = exec.Command(execBinary, "find")
 			out, err = cmd.CombinedOutput()
 			mustError(t, err, string(out))
-			assertContains(t, string(out), "not found trashed files", "should not list deleted file")
+			assertContains(t, string(out), "not found: trashed files", "should not list deleted file")
 		})
 	}
 }


### PR DESCRIPTION
`prune` sub command is added.

Date-based is almost the same as find, but size-based automatically deletes large files first so that the trash can is no larger than the specified size.

This is useful when one does not want to empty the trash can, but want to keep the size below a certain level.

Also added the trash-dir option to find.