### PR TITLE
change formatting of placeholders in input prompts

### DIFF
--- a/internal/cmd/put.go
+++ b/internal/cmd/put.go
@@ -187,7 +187,7 @@ func putCmdRun(args []string, opts putOptions) error {
 		if opts.prompt {
 			prompt := fmt.Sprintf("Do you trash %s %q? ", posix.FileType(st), arg)
 			choices := []string{"yes", "no", "all-yes", "quit"}
-			selected, err := tui.ChoicePrompt(prompt, choices, nil)
+			selected, err := tui.ChoicePrompt(prompt, choices)
 			if err != nil {
 				// canceled
 				return err

--- a/internal/cmd/restore.go
+++ b/internal/cmd/restore.go
@@ -228,7 +228,7 @@ func doRestore(files []trash.File, restoreTo string, prompt bool) error {
 					choice = []string{"new-name", "skip", "repeat-prev", "quit"}
 				}
 				// TODO: Make the message easy to understand
-				selected, err = tui.ChoicePrompt(fmt.Sprintf("Conflicted restore path %q\n\tPlease choose one of the following: ", file.OriginalPath), choice, nil)
+				selected, err = tui.ChoicePrompt(fmt.Sprintf("Conflicted restore path %q\n\tPlease choose one of the following: ", file.OriginalPath), choice)
 				if err != nil {
 					return err
 				}

--- a/internal/tui/boolInputModel.go
+++ b/internal/tui/boolInputModel.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -12,25 +13,25 @@ type boolInputModel struct {
 	confirmed bool
 }
 
-func yesno(s string) (bool, error) {
+func yesno(s string) (bool, string, error) {
 	if s == "" {
-		return false, errors.New("empty")
+		return false, "", errors.New("empty")
 	}
-	switch s[0:1] {
+	switch strings.ToLower(s[0:1]) {
 	case "y":
-		return true, nil
+		return true, "Yes", nil
 	case "n":
-		return false, nil
+		return false, "No", nil
 	}
-	return false, errors.New("unknown")
+	return false, "", errors.New("unknown")
 }
 
 func newBoolInputModel(prompt string) boolInputModel {
 	textInput := textinput.New()
 	textInput.Prompt = prompt
-	textInput.Placeholder = "yes/no"
+	textInput.Placeholder = "(Yes/No)"
 	textInput.Validate = func(value string) error {
-		_, err := yesno(value)
+		_, _, err := yesno(value)
 		return err
 	}
 	textInput.Focus()
@@ -57,8 +58,9 @@ func (m boolInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	var cmd tea.Cmd
 	m.textInput, cmd = m.textInput.Update(msg)
-	if _, err := yesno(m.textInput.Value()); err == nil {
+	if _, value, err := yesno(m.textInput.Value()); err == nil {
 		m.textInput.Blur()
+		m.textInput.SetValue(value)
 		m.confirmed = true
 		return m, tea.Quit
 	}
@@ -67,8 +69,7 @@ func (m boolInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m boolInputModel) Value() bool {
 	valueStr := m.textInput.Value()
-
-	v, _ := yesno(valueStr)
+	v, _, _ := yesno(valueStr)
 	return v
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -59,8 +59,8 @@ func BoolPrompt(prompt string) bool {
 	return false
 }
 
-func ChoicePrompt(prompt string, choices []string, defaultValue *string) (string, error) {
-	model := newChoiceInputModel(prompt, choices, defaultValue)
+func ChoicePrompt(prompt string, choices []string) (string, error) {
+	model := newChoiceInputModel(prompt, choices)
 	result, err := tea.NewProgram(model).Run()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fix #9 

* Change prompt formats such as following
  * gtrash put -i README.md
    * before: Do you trash regular file "README.md"? yes/no/all-yes/quit
    * after: Do you trash regular file "README.md"? (Yes/No/All-yes/Quit)
  * gtrash find blabla --rm
    * before: Are you sure you want to remove PERMANENTLY? yes/no
    * after: Are you sure you want to remove PERMANENTLY? (Yes/No)
* Show the full selection option when prompt is confirmed
  * before: Are you sure you want to remove PERMANENTLY? n
  * after: Are you sure you want to remove PERMANENTLY? No
* Accepts both upper and lower case letters

